### PR TITLE
Update scripts to use python3 and remove hard coding of serial port

### DIFF
--- a/Scripts/play_r08.py
+++ b/Scripts/play_r08.py
@@ -1,14 +1,28 @@
-import serial, sys, time, psutil, os, bz2, gc
+#!/usr/bin/python3
+import serial, sys, time, os, bz2, gc
 
 # disable gc
 gc.disable()
-	
-# give us high priority
-p = psutil.Process(os.getpid())
-p.nice(psutil.REALTIME_PRIORITY_CLASS)
 
+# disambiguiate commandline arguments
+argv_offset = 0
+
+# determine if we were started with python nameOfScript vs ./nameOfScript
+if (sys.argv[0].startswith("python")):
+  argv_offset = 1
+
+# not enough arguments - print usage
+if len(sys.argv) < (3 + argv_offset):
+  sys.stderr.write('Usage: ' + (sys.argv[0] if argv_offset == 1 else '') + sys.argv[0 + argv_offset] + ' <interface> <replayfile>\n\n')
+  sys.exit(0)
+
+# if movie file doesn't exist
+if not os.path.exists(sys.argv[2 + argv_offset]):
+  sys.stderr.write('Error: "' + sys.argv[2 + argv_offset] + '" not found\n')
+  sys.exit(1)
+  
 # connect to device
-ser = serial.Serial('COM3', 2000000, timeout=0.1)
+ser = serial.Serial(sys.argv[1 + argv_offset], 2000000, timeout=0.1)
 
 # send "ping" command to make sure device is there
 ser.write(b'\xFF')

--- a/Scripts/play_r16m.py
+++ b/Scripts/play_r16m.py
@@ -1,14 +1,28 @@
-import serial, sys, time, psutil, os, bz2, gc
+#!/usr/bin/python3
+import serial, sys, time, os, bz2, gc
 
 # disable gc
 gc.disable()
-
-# give us high priority
-p = psutil.Process(os.getpid())
-p.nice(psutil.REALTIME_PRIORITY_CLASS)
 	
+# disambiguiate commandline arguments
+argv_offset = 0
+
+# determine if we were started with python nameOfScript vs ./nameOfScript
+if (sys.argv[0].startswith("python")):
+  argv_offset = 1
+
+# not enough arguments - print usage
+if len(sys.argv) < (3 + argv_offset):
+  sys.stderr.write('Usage: ' + (sys.argv[0] if argv_offset == 1 else '') + sys.argv[0 + argv_offset] + ' <interface> <replayfile>\n\n')
+  sys.exit(0)
+
+# if movie file doesn't exist
+if not os.path.exists(sys.argv[2 + argv_offset]):
+  sys.stderr.write('Error: "' + sys.argv[2 + argv_offset] + '" not found\n')
+  sys.exit(1)
+  
 # connect to device
-ser = serial.Serial('COM3', 2000000, timeout=0.1)
+ser = serial.Serial(sys.argv[1 + argv_offset], 2000000, timeout=0.1)
 
 # send "ping" command to make sure device is there
 ser.write(b'\xFF')

--- a/Scripts/play_r16y.py
+++ b/Scripts/play_r16y.py
@@ -4,14 +4,19 @@ import serial, sys, time, os, bz2, gc
 # disable gc
 gc.disable()
 
+# disambiguiate commandline arguments
 argv_offset = 0
+
+# determine if we were started with python nameOfScript vs ./nameOfScript
 if (sys.argv[0].startswith("python")):
   argv_offset = 1
 
+# not enough arguments - print usage
 if len(sys.argv) < (3 + argv_offset):
   sys.stderr.write('Usage: ' + (sys.argv[0] if argv_offset == 1 else '') + sys.argv[0 + argv_offset] + ' <interface> <replayfile>\n\n')
   sys.exit(0)
-	
+
+# if movie file doesn't exist
 if not os.path.exists(sys.argv[2 + argv_offset]):
   sys.stderr.write('Error: "' + sys.argv[2 + argv_offset] + '" not found\n')
   sys.exit(1)

--- a/Scripts/play_r16y_SMB3.py
+++ b/Scripts/play_r16y_SMB3.py
@@ -4,14 +4,19 @@ import serial, sys, time, os, bz2, gc
 # disable gc
 gc.disable()
 
+# disambiguiate commandline arguments
 argv_offset = 0
+
+# determine if we were started with python nameOfScript vs ./nameOfScript
 if (sys.argv[0].startswith("python")):
   argv_offset = 1
 
+# not enough arguments - print usage
 if len(sys.argv) < (3 + argv_offset):
   sys.stderr.write('Usage: ' + (sys.argv[0] if argv_offset == 1 else '') + sys.argv[0 + argv_offset] + ' <interface> <replayfile>\n\n')
   sys.exit(0)
-	
+
+# if movie file doesn't exist
 if not os.path.exists(sys.argv[2 + argv_offset]):
   sys.stderr.write('Error: "' + sys.argv[2 + argv_offset] + '" not found\n')
   sys.exit(1)

--- a/Scripts/play_r16y_cmd_init.py
+++ b/Scripts/play_r16y_cmd_init.py
@@ -4,14 +4,19 @@ import serial, sys, time, os, bz2, gc
 # disable gc
 gc.disable()
 
+# disambiguiate commandline arguments
 argv_offset = 0
+
+# determine if we were started with python nameOfScript vs ./nameOfScript
 if (sys.argv[0].startswith("python")):
   argv_offset = 1
 
+# not enough arguments - print usage
 if len(sys.argv) < (3 + argv_offset):
   sys.stderr.write('Usage: ' + (sys.argv[0] if argv_offset == 1 else '') + sys.argv[0 + argv_offset] + ' <interface> <replayfile>\n\n')
   sys.exit(0)
-	
+
+# if movie file doesn't exist
 if not os.path.exists(sys.argv[2 + argv_offset]):
   sys.stderr.write('Error: "' + sys.argv[2 + argv_offset] + '" not found\n')
   sys.exit(1)

--- a/Scripts/play_r16y_cmd_resync_stdin.py
+++ b/Scripts/play_r16y_cmd_resync_stdin.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
-
-import serial, sys, time, os, bz2, gc, select
+import serial, sys, time, os, bz2, gc
 
 # disable gc
 gc.disable()

--- a/Scripts/recover.py
+++ b/Scripts/recover.py
@@ -1,7 +1,20 @@
-import serial, sys, time, os, bz2, gc
+#!/usr/bin/python3
+import serial
+
+# disambiguiate commandline arguments
+argv_offset = 0
+
+# determine if we were started with python nameOfScript vs ./nameOfScript
+if (sys.argv[0].startswith("python")):
+  argv_offset = 1
+
+# not enough arguments - print usage
+if len(sys.argv) < (2 + argv_offset):
+  sys.stderr.write('Usage: ' + (sys.argv[0] if argv_offset == 1 else '') + sys.argv[0 + argv_offset] + ' <interface>\n\n')
+  sys.exit(0)
 
 # connect to device
-ser = serial.Serial(sys.argv[1], 2000000, timeout=0.1)
+ser = serial.Serial(sys.argv[1 + argv_offset], 2000000, timeout=0.1)
 
 for i in range(0,30):
   data = []


### PR DESCRIPTION
Add shebang line to allow scripts to be ran directly without specifying
python on the command line.

Add execute bit to *.py files

Modify scripts to remove hardcoding of serial port within the script,
instead get the serial port via command line arguments.

Add basic command line argument checking for scripts