### PR TITLE
Fix python shebang line, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ The replay device is supported on any platform that supports Python3 and support
       * NES - play_r08.py
       * SNES YCable/Single - play_r16y.py
       * SNES Multitap - play_r16m.py
-    * NOTE: it is intended to make this more user friendly in the future. As the files are not consistent in taking command line arguments, etc.
-    * Type: `python3 {nameOfScript} {serialDevice} {pathToMovieFile}`
+    * Type: `python3 {nameOfScript} {serialDevice} {pathToMovieFile}` OR `./{nameOfScript} {serialDevice} {pathToMovieFile}`
       * Where `{nameOfScript}` is the name of one of the scripts listed above
       * Where `{serialDevice}` is the name/path of the serial device created by the replay device. example: `/dev/ttyACM0`, `COM3`, `/dev/tty.usbmodem1411`, etc.
       * Where `{pathToMovieFile}` is the path to an .r08 or.r16m.

--- a/Scripts/play_r08.py
+++ b/Scripts/play_r08.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import serial, sys, time, os, bz2, gc
 
 # disable gc

--- a/Scripts/play_r16m.py
+++ b/Scripts/play_r16m.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import serial, sys, time, os, bz2, gc
 
 # disable gc

--- a/Scripts/play_r16y.py
+++ b/Scripts/play_r16y.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import serial, sys, time, os, bz2, gc
 
 # disable gc

--- a/Scripts/play_r16y_SMB3.py
+++ b/Scripts/play_r16y_SMB3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import serial, sys, time, os, bz2, gc
 
 # disable gc

--- a/Scripts/play_r16y_cmd_init.py
+++ b/Scripts/play_r16y_cmd_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import serial, sys, time, os, bz2, gc
 
 # disable gc

--- a/Scripts/play_r16y_cmd_resync_stdin.py
+++ b/Scripts/play_r16y_cmd_resync_stdin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import serial, sys, time, os, bz2, gc
 
 # disable gc

--- a/Scripts/recover.py
+++ b/Scripts/recover.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-import serial
+#!/usr/bin/env python3
+import serial, sys
 
 # disambiguiate commandline arguments
 argv_offset = 0


### PR DESCRIPTION
Use /usr/bin/env python3 to allow for more cross platform compatibility
for where python is installed

Update readme to indicate "./" syntax is now allowed