### PR TITLE
Add *.r*m to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ Backup
 *.cydsn/*_timing.html
 *.cydsn/Export
 ComponentUpdateLog.txt
-
+*.r*m


### PR DESCRIPTION
*.r*m files are movie files that users may bring into this repo. Add
them to the gitignore so they don't accidentally get committed.